### PR TITLE
Fixing CSV parsing errors.

### DIFF
--- a/lib/packer/output/machine_readable.rb
+++ b/lib/packer/output/machine_readable.rb
@@ -18,7 +18,7 @@ module Packer
       def select_messages(type)
         stdout
           .split("\n")
-          .map { |line| CSV.parse(line).first }
+          .map { |line| CSV.parse(line, quote_char: "\x00").first }
           .select { |fields| fields[2] == type }
       end
     end

--- a/spec/unit/packer/output/machine_readable_spec.rb
+++ b/spec/unit/packer/output/machine_readable_spec.rb
@@ -4,15 +4,27 @@ describe Packer::Output::MachineReadable do
   describe '#ui_messages' do
     let(:output) { 'timestamp,,ui,say,example' }
 
-    subject { described_class.new(shellout_double(output)) }
+    let(:bad_output) { 'timestamp,,ui,say,setting tags: "name": "a name"' }
 
-    it 'returns an array of UI messages' do
-      expect(subject.ui_messages.length).to eq(1)
-      expect(subject.ui_messages[0].timestamp).to eq('timestamp')
-      expect(subject.ui_messages[0].target).to be_nil
-      expect(subject.ui_messages[0].type).to eq('ui')
-      expect(subject.ui_messages[0].ui_message_type).to eq('say')
-      expect(subject.ui_messages[0].output).to eq('example')
+    context 'the output is RFC compliant' do
+      subject { described_class.new(shellout_double(output)) }
+
+      it 'returns an array of UI messages' do
+        expect(subject.ui_messages.length).to eq(1)
+        expect(subject.ui_messages[0].timestamp).to eq('timestamp')
+        expect(subject.ui_messages[0].target).to be_nil
+        expect(subject.ui_messages[0].type).to eq('ui')
+        expect(subject.ui_messages[0].ui_message_type).to eq('say')
+        expect(subject.ui_messages[0].output).to eq('example')
+      end
+    end
+
+    context 'the output has quote characters in fields' do
+      subject { described_class.new(shellout_double(bad_output)) }
+
+      it 'does not throw a parsing error' do
+        expect(subject.ui_messages.length).to eq(1)
+      end
     end
   end
 end


### PR DESCRIPTION
Some output from packer's -machine-readable is not compliant with the CSV RFC (https://tools.ietf.org/html/rfc4180).

This results in errors being thrown by CSV parse.  Unless you wanted to restrict yourself to Ruby 2.4.0, the only way to convince the stdlib CSV parser to behave is to give it a fake quote character.